### PR TITLE
Fix the unreliable loading of the custom viewer plugin

### DIFF
--- a/glue/config.py
+++ b/glue/config.py
@@ -352,8 +352,7 @@ class QtClientRegistry(Registry):
     def default_members(self):
         try:
             from glue.qt.widgets import default_widgets
-            from glue.qt.custom_viewer import CUSTOM_WIDGETS
-            return default_widgets + CUSTOM_WIDGETS
+            return default_widgets
         except ImportError as e:
             logging.getLogger(__name__).warning(
                 "could not import glue.qt in ConfigObject")

--- a/glue/qt/custom_viewer.py
+++ b/glue/qt/custom_viewer.py
@@ -79,6 +79,8 @@ from glue.external import six
 from glue.external.qt import QtGui
 from glue.external.qt.QtCore import Qt
 
+from glue.config import qt_client
+
 from glue.clients import LayerArtist, GenericMplClient
 from glue.core import Data
 from glue.core.edit_subset_mode import EditSubsetMode
@@ -90,8 +92,6 @@ from glue.qt import widget_properties as wp
 from glue.qt.widgets import MplWidget
 from glue.qt.glue_toolbar import GlueToolbar
 from glue.qt.mouse_mode import PolyMode, RectangleMode
-
-CUSTOM_WIDGETS = []
 
 __all__ = ["AttributeInfo", "ViewerState", "UserDefinedFunction",
            "CustomViewer", "SettingsOracleInterface", "SettingsOracle",
@@ -574,7 +574,7 @@ class CustomViewer(object):
                           widget_dict)
 
         cls._widget_cls = widget_cls
-        CUSTOM_WIDGETS.append(widget_cls)
+        qt_client.add(widget_cls)
 
         # add new classes to module namespace
         # needed for proper state saving/restoring


### PR DESCRIPTION
This fixes the fact that the loading of the custom viewer is unreliable (it was due to a race condition if other plugins were loaded before yours)
